### PR TITLE
ci: deprecate tmpdir in favour of tmp_path

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -1006,12 +1006,6 @@ version = "0.7.0"
 summary = "Run a subprocess in a pseudo terminal"
 
 [[package]]
-name = "py"
-version = "1.11.0"
-requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-summary = "library with cross-python path, ini-parsing, io, code, log facilities"
-
-[[package]]
 name = "pycodestyle"
 version = "2.8.0"
 requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -1139,16 +1133,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pytest-forked"
-version = "1.4.0"
-requires_python = ">=3.6"
-summary = "run tests in isolated forked subprocesses"
-dependencies = [
-    "py",
-    "pytest>=3.10",
-]
-
-[[package]]
 name = "pytest-freezegun"
 version = "0.4.2"
 summary = "Wrap tests with fixtures in freeze_time"
@@ -1159,12 +1143,11 @@ dependencies = [
 
 [[package]]
 name = "pytest-xdist"
-version = "2.5.0"
+version = "3.0.2"
 requires_python = ">=3.6"
 summary = "pytest xdist plugin for distributed testing and loop-on-failing modes"
 dependencies = [
     "execnet>=1.1",
-    "pytest-forked",
     "pytest>=6.2.0",
 ]
 
@@ -2318,10 +2301,6 @@ content_hash = "sha256:ede2dac46f7b70cde6b3da40a7a4b6af2958e68d36ac730ce619136c4
     {url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
     {url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
 ]
-"py 1.11.0" = [
-    {url = "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
-    {url = "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
-]
 "pycodestyle 2.8.0" = [
     {url = "https://files.pythonhosted.org/packages/08/dc/b29daf0a202b03f57c19e7295b60d1d5e1281c45a6f5f573e41830819918/pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
     {url = "https://files.pythonhosted.org/packages/15/94/bc43a2efb7b8615e38acde2b6624cae8c9ec86faf718ff5676c5179a7714/pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
@@ -2415,17 +2394,13 @@ content_hash = "sha256:ede2dac46f7b70cde6b3da40a7a4b6af2958e68d36ac730ce619136c4
     {url = "https://files.pythonhosted.org/packages/ea/70/da97fd5f6270c7d2ce07559a19e5bf36a76f0af21500256f005a69d9beba/pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
     {url = "https://files.pythonhosted.org/packages/fe/1f/9ec0ddd33bd2b37d6ec50bb39155bca4fe7085fa78b3b434c05459a860e3/pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
 ]
-"pytest-forked 1.4.0" = [
-    {url = "https://files.pythonhosted.org/packages/0c/36/c56ef2aea73912190cdbcc39aaa860db8c07c1a5ce8566994ec9425453db/pytest_forked-1.4.0-py3-none-any.whl", hash = "sha256:bbbb6717efc886b9d64537b41fb1497cfaf3c9601276be8da2cccfea5a3c8ad8"},
-    {url = "https://files.pythonhosted.org/packages/f1/bc/0121a2e386b261b69f4f5aa48e5304c947451dce70d68628cb28d5cd0d28/pytest-forked-1.4.0.tar.gz", hash = "sha256:8b67587c8f98cbbadfdd804539ed5455b6ed03802203485dd2f53c1422d7440e"},
-]
 "pytest-freezegun 0.4.2" = [
     {url = "https://files.pythonhosted.org/packages/9e/09/0bdd7d24b9d21453ad3364ae1efbd65082045bb6081b5fd5eade91a9b644/pytest_freezegun-0.4.2-py2.py3-none-any.whl", hash = "sha256:5318a6bfb8ba4b709c8471c94d0033113877b3ee02da5bfcd917c1889cde99a7"},
     {url = "https://files.pythonhosted.org/packages/f0/e3/c39d7c3d3afef5652f19323f3483267d7e6b0d9911c3867e10d6e2d3c9ae/pytest-freezegun-0.4.2.zip", hash = "sha256:19c82d5633751bf3ec92caa481fb5cffaac1787bd485f0df6436fd6242176949"},
 ]
-"pytest-xdist 2.5.0" = [
-    {url = "https://files.pythonhosted.org/packages/21/08/b1945d4b4986eb1aa10cf84efc5293bba39da80a2f95db3573dd90678408/pytest_xdist-2.5.0-py3-none-any.whl", hash = "sha256:6fe5c74fec98906deb8f2d2b616b5c782022744978e7bd4695d39c8f42d0ce65"},
-    {url = "https://files.pythonhosted.org/packages/5d/43/9dbc32d297d6eae85d6c05dc8e8d3371061bd6cbe56a2f645d9ea4b53d9b/pytest-xdist-2.5.0.tar.gz", hash = "sha256:4580deca3ff04ddb2ac53eba39d76cb5dd5edeac050cb6fbc768b0dd712b4edf"},
+"pytest-xdist 3.0.2" = [
+    {url = "https://files.pythonhosted.org/packages/0b/74/3ba11ebecb6f3f69a472a3c19be65c46a1dd3efaa580d973118455c74c34/pytest-xdist-3.0.2.tar.gz", hash = "sha256:688da9b814370e891ba5de650c9327d1a9d861721a524eb917e620eec3e90291"},
+    {url = "https://files.pythonhosted.org/packages/0e/99/2b300b4391f27ba31c6ec1ce643700ee2d32f860e3877a13106ef3a30e22/pytest_xdist-3.0.2-py3-none-any.whl", hash = "sha256:9feb9a18e1790696ea23e1434fa73b325ed4998b0e9fcb221f16fd1945e6df1b"},
 ]
 "python-dateutil 2.8.2" = [
     {url = "https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,12 @@
 """Store the classes and fixtures used throughout the tests."""
 
 import os
+from pathlib import Path
 from typing import Any, Dict, Generator
 
 import boto3
 import pytest
 from moto import mock_autoscaling, mock_ec2, mock_iam, mock_rds, mock_route53, mock_s3
-from py._path.local import LocalPath
 from repository_orm import FakeRepository, TinyDBRepository
 
 from clinv.adapters.fake import FakeSource
@@ -28,15 +28,13 @@ def fixture_config(db_tinydb: str) -> Config:
 
 
 @pytest.fixture(name="db_tinydb")
-def db_tinydb_(tmpdir: LocalPath) -> str:
+def db_tinydb_(tmp_path: Path) -> str:
     """Create the TinyDB database url.
 
     Returns:
         database_url: Url used to connect to the database.
     """
-    # ignore: Call of untyped join function in typed environment.
-    # Until they give typing information there is nothing else to do.
-    tinydb_file_path = str(tmpdir.join("tinydb.db"))  # type: ignore
+    tinydb_file_path = str(tmp_path / "tinydb.db")
 
     tinydb_url = f"tinydb:///{tinydb_file_path}"
 


### PR DESCRIPTION
<!--
Thank you for sending a pull request!

Please describe what the change is, trying to link it with open issues.
-->

## Checklist

* [ ] Add test cases to all the changes you introduce
* [ ] Update the documentation for the changes
